### PR TITLE
API improvement and optimization work.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/omni-viral/chains.git"
 readme = "README.md"
 license = "MIT/Apache-2.0"
 
+[profile.release]
+debug = 2
+
 [dependencies]
 derivative = "1.0"
 gfx-hal = { version = "0.1.0", git = "https://github.com/gfx-rs/gfx", rev = "54fe14fbb" }

--- a/examples/random_chains.rs
+++ b/examples/random_chains.rs
@@ -95,7 +95,7 @@ fn create_image_layout(rng: &mut DefaultRng) -> ImageLayout {
         ImageLayout::ShaderReadOnlyOptimal,
         ImageLayout::TransferSrcOptimal,
         ImageLayout::TransferDstOptimal,
-        //ImageLayout::Present, // FIXME
+        ImageLayout::Present,
     ]).unwrap()
 }
 

--- a/src/chain/link.rs
+++ b/src/chain/link.rs
@@ -188,6 +188,6 @@ impl<'a, R: Resource + 'a> Iterator for QueuesIter<'a, R> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (0, None)
+        (0, self.iter.size_hint().1)
     }
 }

--- a/src/chain/link.rs
+++ b/src/chain/link.rs
@@ -11,10 +11,10 @@ use schedule::{QueueId, SubmissionId};
 /// Contains submissions range, combined access and stages bits by submissions from the range.
 #[derive(Clone, Debug)]
 pub(crate) struct LinkQueueState<R: Resource> {
-    first: usize,
-    last: usize,
-    access: R::Access,
-    stages: PipelineStage,
+    pub first: usize,
+    pub last: usize,
+    pub access: R::Access,
+    pub stages: PipelineStage,
 }
 
 impl<R> LinkQueueState<R>
@@ -34,16 +34,6 @@ where
         self.access |= state.access;
         self.stages |= state.stages;
         self.last = sid.index();
-    }
-
-    /// First submission index.
-    pub fn first(&self) -> usize {
-        self.first
-    }
-
-    /// Last submission index.
-    pub fn last(&self) -> usize {
-        self.last
     }
 }
 
@@ -166,7 +156,7 @@ where
 
     ///
     pub(crate) fn queue_state(&self, qid: QueueId) -> State<R> {
-        let queue = self.queue(qid).unwrap();
+        let queue = self.queue(qid);
         State {
             access: queue.access,
             stages: queue.stages,
@@ -174,13 +164,9 @@ where
         }
     }
 
-    pub(crate) fn queue(&self, qid: QueueId) -> Option<&LinkQueueState<R>> {
+    pub(crate) fn queue(&self, qid: QueueId) -> &LinkQueueState<R> {
         debug_assert_eq!(self.family, qid.family());
-        if qid.index() < self.queues.len() {
-            self.queues[qid.index()].as_ref()
-        } else {
-            None
-        }
+        self.queues[qid.index()].as_ref().unwrap()
     }
 }
 

--- a/src/chain/link.rs
+++ b/src/chain/link.rs
@@ -1,4 +1,5 @@
-use std::collections::hash_map::{Entry, HashMap, Iter as HashMapIter};
+use std::iter::Enumerate;
+use std::slice::{Iter as SliceIter};
 
 use hal::pso::PipelineStage;
 use hal::queue::QueueFamilyId;
@@ -54,7 +55,8 @@ where
 pub struct Link<R: Resource> {
     usage: R::Usage,
     state: State<R>,
-    queues: HashMap<usize, LinkQueueState<R>>,
+    queue_count: usize,
+    queues: Vec<Option<LinkQueueState<R>>>,
     family: QueueFamilyId,
 }
 
@@ -70,12 +72,25 @@ where
     /// `sid`       - id of the first submission.
     ///
     pub fn new(sid: SubmissionId, state: State<R>, usage: R::Usage) -> Self {
-        use std::iter::once;
-        Link {
+        let mut link = Link {
             state,
-            queues: once((sid.queue().index(), LinkQueueState::new(sid, state))).collect(),
+            queue_count: 1,
+            queues: Vec::new(),
             family: sid.family(),
             usage,
+        };
+        link.ensure_queue(sid.queue().index());
+        link.queues[sid.queue().index()] = Some(LinkQueueState::new(sid, state));
+        link
+    }
+
+    fn ensure_queue(&mut self, index: usize) {
+        if index >= self.queues.len() {
+            let reserve = index - self.queues.len() + 1;
+            self.queues.reserve(reserve);
+            while index >= self.queues.len() {
+                self.queues.push(None);
+            }
         }
     }
 
@@ -95,16 +110,9 @@ where
         self.state
     }
 
-    /// Check if the link is associated with only one submission.
-    pub fn exclusive(&self) -> bool {
-        let mut values = self.queues.values();
-        let queue = values.next().unwrap();
-        values.next().is_none() && queue.first() == queue.last()
-    }
-
     /// Check if the link is associated with only one queue.
     pub fn single_queue(&self) -> bool {
-        self.queues().len() == 1
+        self.queue_count == 1
     }
 
     /// Check if the given state and submission are compatible with link.
@@ -127,33 +135,20 @@ where
     ///
     pub fn insert_submission(&mut self, sid: SubmissionId, state: State<R>, usage: R::Usage) {
         assert_eq!(self.family, sid.family());
+        self.ensure_queue(sid.queue().index());
+
         let state = self.state.merge(state);
-        match self.queues.entry(sid.queue().index()) {
-            Entry::Occupied(mut occupied) => {
-                occupied.get_mut().push(sid, state);
+        match &mut self.queues[sid.queue().index()] {
+            &mut Some(ref mut queue) => {
+                queue.push(sid, state);
             }
-            Entry::Vacant(vacant) => {
-                vacant.insert(LinkQueueState::new(sid, state));
+            slot @ &mut None => {
+                self.queue_count += 1;
+                *slot = Some(LinkQueueState::new(sid, state));
             }
-        };
+        }
         self.state = state;
         self.usage |= usage;
-    }
-
-    /// Collect first submissions from all queues.
-    pub fn heads(&self) -> Vec<SubmissionId> {
-        self.queues
-            .iter()
-            .map(|(&index, queue)| SubmissionId::new(QueueId::new(self.family, index), queue.first()))
-            .collect()
-    }
-
-    /// Collect last submissions from all queues.
-    pub fn tails(&self) -> Vec<SubmissionId> {
-        self.queues
-            .iter()
-            .map(|(&index, queue)| SubmissionId::new(QueueId::new(self.family, index), queue.last()))
-            .collect()
     }
 
     /// Check if ownership transfer is required between those links.
@@ -165,7 +160,7 @@ where
     pub(crate) fn queues(&self) -> QueuesIter<R> {
         QueuesIter {
             family: self.family,
-            iter: self.queues.iter(),
+            iter: self.queues.iter().enumerate(),
         }
     }
 
@@ -180,35 +175,33 @@ where
     }
 
     pub(crate) fn queue(&self, qid: QueueId) -> Option<&LinkQueueState<R>> {
-        assert_eq!(self.family, qid.family());
-        self.queues.get(&qid.index())
+        debug_assert_eq!(self.family, qid.family());
+        if qid.index() < self.queues.len() {
+            self.queues[qid.index()].as_ref()
+        } else {
+            None
+        }
     }
 }
 
 pub(crate) struct QueuesIter<'a, R: Resource + 'a> {
     family: QueueFamilyId,
-    iter: HashMapIter<'a, usize, LinkQueueState<R>>,
+    iter: Enumerate<SliceIter<'a, Option<LinkQueueState<R>>>>,
 }
 
-impl<'a, R> Iterator for QueuesIter<'a, R>
-where
-    R: Resource + 'a,
-{
+impl<'a, R: Resource + 'a> Iterator for QueuesIter<'a, R> {
     type Item = (QueueId, &'a LinkQueueState<R>);
 
     fn next(&mut self) -> Option<(QueueId, &'a LinkQueueState<R>)> {
-        self.iter
-            .next()
-            .map(|(&index, queue)| (QueueId::new(self.family, index), queue))
+        while let Some((index, state)) = self.iter.next() {
+            if let &Some(ref queue) = state {
+                return Some((QueueId::new(self.family, index), queue))
+            }
+        }
+        None
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.size_hint()
+        (0, None)
     }
-}
-
-impl<'a, R> ExactSizeIterator for QueuesIter<'a, R>
-where
-    R: Resource + 'a,
-{
 }

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -32,7 +32,7 @@ where
     /// Create new empty `Chain`
     pub fn new() -> Self {
         Chain {
-            links: Vec::new()
+            links: Vec::new(),
         }
     }
 

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -6,15 +6,17 @@
 
 use std::cmp::max;
 use std::collections::HashMap;
+use std::hash::Hash;
+use std::ops::Range;
 use hal::queue::QueueFamilyId;
 
 use chain::{BufferChains, Chain, ImageChains, Link};
 use pass::{Pass, PassId, StateUsage};
-use resource::{Resource, State, Usage};
+use resource::{Buffer, Image, Resource, State};
 
 use Pick;
 use resource::Id;
-use schedule::{QueueId, Schedule, Submission, SubmissionId};
+use schedule::{Queue, QueueId, Schedule, Submission, SubmissionId};
 
 /// Placeholder for synchronization type.
 #[derive(Debug)]
@@ -39,48 +41,93 @@ struct Fitness {
     wait_factor: usize,
 }
 
+struct ResolvedPass {
+    id: usize,
+    family: QueueFamilyId,
+    queues: Range<usize>,
+    deps: Vec<usize>,
+    buffers: Vec<(usize, StateUsage<Buffer>)>,
+    images: Vec<(usize, StateUsage<Image>)>,
+}
+
+struct ResolvedPassSet {
+    passes: Vec<ResolvedPass>,
+    pass_ids: Vec<PassId>,
+    queues: Vec<QueueId>,
+    buffers: Vec<Id<Buffer>>,
+    images: Vec<Id<Image>>,
+}
+
+struct ChainData<R: Resource> {
+    chain: Chain<R>,
+    last_link_wait_factor: usize,
+    current_link_wait_factor: usize,
+    current_family: Option<QueueFamilyId>,
+}
+impl <R: Resource> Default for ChainData<R> {
+    fn default() -> Self {
+        ChainData {
+            chain: Chain::new(),
+            last_link_wait_factor: 0,
+            current_link_wait_factor: 0,
+            current_family: None,
+        }
+    }
+}
+
+struct QueueData {
+    queue: Queue<Unsynchronized>,
+    wait_factor: usize,
+}
+
 /// Calculate automatic `Chains` for passes.
 /// This function tries to find most appropriate schedule for passes execution.
-pub fn collect<Q>(mut passes: Vec<Pass>, max_queues: Q) -> Chains
+pub fn collect<Q>(passes: Vec<Pass>, max_queues: Q) -> Chains
 where
     Q: Fn(QueueFamilyId) -> usize,
 {
+    // Resolve passes into a form faster to work with.
+    let mut passes = resolve_passes(passes, max_queues);
+
     // Track scheduled.
-    let mut scheduled: Vec<PassId> = Vec::new();
+    let mut scheduled: Vec<bool> = fill(passes.pass_ids.len());
 
     // Chains.
-    let mut images: ImageChains = ImageChains::new();
-    let mut buffers: BufferChains = BufferChains::new();
+    let mut images: Vec<ChainData<Image>> = fill(passes.images.len());
+    let mut buffers: Vec<ChainData<Buffer>> = fill(passes.buffers.len());
 
     // Schedule
-    let mut schedule = Schedule::default();
+    let mut schedule = Vec::with_capacity(passes.queues.len());
+    for i in 0..passes.queues.len() {
+        schedule.push(QueueData {
+            queue: Queue::new(passes.queues[i]),
+            wait_factor: 0,
+        });
+    }
 
-    while !passes.is_empty() {
-        // Find passes that are ready to be scheduled
-        // E.g. All dependencies are scheduled.
-        scheduled.sort();
+    while !passes.passes.is_empty() {
         // Among ready passes find best fit.
-        let (fitness, qid, index) = passes
+        let (fitness, qid, index) = passes.passes
             .iter()
             .enumerate()
-            .filter(|&(_, pass)| all_there(pass.dependencies(), &scheduled))
+            .filter(|&(_, pass)| pass.deps.iter().all(|&x| scheduled[x]))
             .map(|(index, pass)| {
                 let (fitness, qid) = fitness(
                     pass,
-                    max_queues(pass.family()),
                     &mut images,
                     &mut buffers,
-                    &schedule,
+                    &mut schedule,
                 );
                 (fitness, qid, index)
             })
             .min()
             .unwrap();
 
-        let pass = passes.swap_remove(index);
-        scheduled.push(pass.id);
+        let pass = passes.passes.swap_remove(index);
+        scheduled[pass.id] = true;
 
         schedule_pass(
+            &passes,
             pass,
             qid,
             fitness.wait_factor,
@@ -91,116 +138,178 @@ where
     }
 
     Chains {
-        schedule,
-        buffers,
-        images,
+        schedule: reify_schedule(&passes.queues, schedule),
+        buffers: reify_chain(&passes.buffers, buffers),
+        images: reify_chain(&passes.images, images),
     }
 }
 
-fn all_there(all: &[PassId], there: &[PassId]) -> bool {
-    for &a in all {
-        if there.iter().find(|&&t| t == a).is_none() {
-            return false;
+fn fill<T: Default>(num: usize) -> Vec<T> {
+    let mut vec = Vec::with_capacity(num);
+    for _ in 0..num {
+        vec.push(T::default());
+    }
+    vec
+}
+
+struct LookupBuilder<I : Hash + Eq + Copy> {
+    forward: HashMap<I, usize>,
+    backward: Vec<I>,
+}
+impl <I : Hash + Eq + Copy> LookupBuilder<I> {
+    fn new() -> LookupBuilder<I> {
+        LookupBuilder { forward: HashMap::new(), backward: Vec::new() }
+    }
+    fn get(&mut self, id: I) -> Option<usize> {
+        self.forward.get(&id).cloned()
+    }
+    fn forward(&mut self, id: I) -> usize {
+        if let Some(&id_num) = self.forward.get(&id) {
+            id_num
+        } else {
+            let id_num = self.backward.len();
+            self.backward.push(id);
+            self.forward.insert(id, id_num);
+            id_num
         }
     }
-    true
 }
 
-fn fitness<S>(
-    pass: &Pass,
-    max_queues: usize,
-    images: &mut ImageChains,
-    buffers: &mut BufferChains,
-    schedule: &Schedule<S>,
-) -> (Fitness, QueueId) {
-    // Find best queue for pass.
-    pass.queue()
-        .map_or(0..max_queues, |queue| queue..queue + 1)
-        .map(|index| {
-            let qid = QueueId::new(pass.family(), index);
-            let sid = SubmissionId::new(qid, schedule.queue(qid).map_or(0, |queue| queue.len()));
-
-            let mut result = Fitness {
-                transfers: 0,
-                wait_factor: 0,
-            };
-
-            // Collect minimal waits required and resource transfers count.
-            pass.buffers().for_each(|(id, &state)| {
-                let (t, w) = buffers.get(id).map_or((0, 0), |chain| {
-                    transfers_and_wait_factor(chain, sid, state.state, schedule)
-                });
-                result.transfers += t;
-                result.wait_factor = max(result.wait_factor, w);
-            });
-
-            // Collect minimal waits required and resource transfers count.
-            pass.images().for_each(|(id, &state)| {
-                let (t, w) = images.get(id).map_or((0, 0), |chain| {
-                    transfers_and_wait_factor(chain, sid, state.state, schedule)
-                });
-                result.transfers += t;
-                result.wait_factor = max(result.wait_factor, w);
-            });
-
-            (result, qid)
-        })
-        .min()
-        .unwrap()
-}
-
-fn transfers_and_wait_factor<R, S>(
-    chain: &Chain<R>,
-    sid: SubmissionId,
-    state: State<R>,
-    schedule: &Schedule<S>,
-) -> (usize, usize)
+fn resolve_passes<Q>(passes: Vec<Pass>, max_queues: Q) -> ResolvedPassSet
 where
-    R: Resource,
+    Q: Fn(QueueFamilyId) -> usize,
 {
-    let mut transfers = 0;
-    let mut wait_factor = 0;
+    let mut reified_passes = Vec::new();
+    let mut pass_ids = LookupBuilder::new();
+    let mut queues = LookupBuilder::new();
+    let mut buffers = LookupBuilder::new();
+    let mut images = LookupBuilder::new();
 
-    let fake_link = Link::new(sid, state, R::Usage::none());
-    if let Some(link) = chain.links().last() {
-        transfers += if link.transfer(&fake_link) { 1 } else { 0 };
+    let mut family_full = HashMap::new();
+    for pass in passes {
+        let family = pass.family;
+        if !family_full.contains_key(&family) {
+            let count = max_queues(family);
+            assert!(count > 0, "Cannot create a family with 0 max queues.");
+            for i in 0..count {
+                queues.forward(QueueId::new(family, i));
+            }
 
-        for tail in link.tails() {
-            wait_factor = max(schedule[tail].wait_factor(), wait_factor);
+            let full_range = queues.forward(QueueId::new(family, 0)) ..
+                             queues.forward(QueueId::new(family, count - 1)) + 1;
+            family_full.insert(family, full_range);
         }
+
+        reified_passes.push(ResolvedPass {
+            id: pass_ids.forward(pass.id),
+            family: pass.family,
+            queues: if let Some(queue) = pass.queue {
+                let id = queues
+                    .get(QueueId::new(family, queue))
+                    .expect("Requested queue out of range!");
+                id .. id + 1
+            } else {
+                family_full[&family].clone()
+            },
+            deps: pass.dependencies.into_iter().map(|p| pass_ids.forward(p)).collect(),
+            buffers: pass.buffers.into_iter().map(|(k, v)| (buffers.forward(k), v)).collect(),
+            images: pass.images.into_iter().map(|(k, v)| (images.forward(k), v)).collect(),
+        });
     }
 
-    (transfers, wait_factor)
+    ResolvedPassSet {
+        passes: reified_passes,
+        pass_ids: pass_ids.backward,
+        queues: queues.backward,
+        buffers: buffers.backward,
+        images: images.backward,
+    }
+}
+
+fn reify_chain<R: Resource>(ids: &[Id<R>], vec: Vec<ChainData<R>>) -> HashMap<Id<R>, Chain<R>> {
+    let mut map = HashMap::with_capacity(vec.len());
+    for (chain, &i) in vec.into_iter().zip(ids) {
+        map.insert(i, chain.chain);
+    }
+    map
+}
+
+fn reify_schedule(ids: &[QueueId], vec: Vec<QueueData>) -> Schedule<Unsynchronized> {
+    let mut schedule = Schedule::new();
+    for (queue_data, &i) in vec.into_iter().zip(ids) {
+        *schedule.ensure_queue(i) = queue_data.queue;
+    }
+    schedule
+}
+
+fn fitness(
+    pass: &ResolvedPass,
+    images: &mut Vec<ChainData<Image>>,
+    buffers: &mut Vec<ChainData<Buffer>>,
+    schedule: &mut Vec<QueueData>,
+) -> (Fitness, usize) {
+    let mut transfers = 0;
+    let mut wait_factor_from_chains = 0;
+
+    // Collect minimal waits required and resource transfers count.
+    for &(id, _) in &pass.buffers {
+        let chain = &buffers[id];
+        if chain.current_family.unwrap_or(pass.family) != pass.family {
+            transfers += 1;
+        }
+        wait_factor_from_chains = max(wait_factor_from_chains, chain.last_link_wait_factor);
+    }
+    for &(id, _) in &pass.images {
+        let chain = &images[id];
+        if chain.current_family.unwrap_or(pass.family) != pass.family {
+            transfers += 1;
+        }
+        wait_factor_from_chains = max(wait_factor_from_chains, chain.last_link_wait_factor);
+    }
+
+    // Find best queue for pass.
+    let (wait_factor_from_queue, queue) =
+        pass.queues.clone()
+            .map(|index| (schedule[index].wait_factor, index))
+            .min()
+            .unwrap();
+    (Fitness {
+        transfers,
+        wait_factor: max(wait_factor_from_chains, wait_factor_from_queue),
+    }, queue)
 }
 
 fn schedule_pass(
-    pass: Pass,
-    qid: QueueId,
+    passes: &ResolvedPassSet,
+    pass: ResolvedPass,
+    queue: usize,
     wait_factor: usize,
-    schedule: &mut Schedule<Unsynchronized>,
-    images: &mut ImageChains,
-    buffers: &mut BufferChains,
+    schedule: &mut Vec<QueueData>,
+    images: &mut Vec<ChainData<Image>>,
+    buffers: &mut Vec<ChainData<Buffer>>,
 ) {
-    assert_eq!(qid.family(), pass.family());
+    let pid = passes.pass_ids[pass.id];
+    let ref mut queue_data = schedule[queue];
+    queue_data.wait_factor = max(queue_data.wait_factor, wait_factor + 1);
+    let sid = queue_data.queue.add_submission(Submission::new(wait_factor, pid, Unsynchronized));
+    let ref mut submission = queue_data.queue[sid];
 
-    let ref mut queue = schedule.ensure_queue(qid);
-    let sid = queue.add_submission(Submission::new(wait_factor, pass.id, Unsynchronized));
-    let ref mut submission = queue[sid];
-
-    for (&id, &StateUsage { state, usage }) in pass.buffers() {
-        let chain = buffers.entry(id).or_insert_with(|| Chain::new());
-        add_to_chain(id, chain, sid, submission, state, usage);
+    for (id, StateUsage { state, usage }) in pass.buffers {
+        add_to_chain(
+            passes.buffers[id], pass.family, &mut buffers[id], sid, submission, state, usage,
+        );
     }
-
-    for (&id, &StateUsage { state, usage }) in pass.images() {
-        let chain = images.entry(id).or_insert_with(|| Chain::new());
-        add_to_chain(id, chain, sid, submission, state, usage);
+    for (id, StateUsage { state, usage }) in pass.images {
+        add_to_chain(
+            passes.images[id], pass.family, &mut images[id], sid, submission, state, usage,
+        );
     }
 }
 
 fn add_to_chain<R, S>(
     id: Id<R>,
-    chain: &mut Chain<R>,
+    family: QueueFamilyId,
+    chain_data: &mut ChainData<R>,
     sid: SubmissionId,
     submission: &mut Submission<S>,
     state: State<R>,
@@ -209,6 +318,11 @@ fn add_to_chain<R, S>(
     R: Resource,
     Submission<S>: Pick<R, Target = HashMap<Id<R>, usize>>,
 {
+    chain_data.current_family = Some(family);
+    chain_data.current_link_wait_factor =
+        max(submission.wait_factor() + 1, chain_data.current_link_wait_factor);
+
+    let ref mut chain = chain_data.chain;
     let chain_len = chain.links().len();
     let append = match chain.last_link_mut() {
         Some(ref mut link) if link.compatible(sid, state) => {
@@ -218,6 +332,7 @@ fn add_to_chain<R, S>(
         }
         Some(_) | None => {
             submission.pick_mut().insert(id, chain_len);
+            chain_data.last_link_wait_factor = chain_data.current_link_wait_factor;
             Some(Link::new(sid, state, usage))
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ trait Pick<R> {
 
 use pass::Pass;
 use collect::{Chains, collect};
-use sync::{sync, Sync};
+use sync::{sync, SyncData};
 
 /// Build synchronized schedule of the execution from passes descriptions.
 /// 
@@ -39,7 +39,7 @@ use sync::{sync, Sync};
 /// `max_queues`    - function that returns maximum number of queues for specified family.
 /// `new_semaphore` - function to create new semaphore pair - (signal, wait).
 /// 
-pub fn build<F, Q, S, W>(passes: Vec<Pass>, max_queues: Q, new_semaphore: F) -> Chains<Sync<S, W>>
+pub fn build<F, Q, S, W>(passes: Vec<Pass>, max_queues: Q, new_semaphore: F) -> Chains<SyncData<S, W>>
 where
     Q: Fn(QueueFamilyId) -> usize,
     F: FnMut() -> (S, W),

--- a/src/pass.rs
+++ b/src/pass.rs
@@ -8,7 +8,7 @@ use hal::queue::QueueFamilyId;
 use resource::{Buffer, Id, Image, State, Resource};
 
 /// Id of the pass.
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct PassId(pub usize);
 
 /// State in which pass uses resource and usage flags.

--- a/src/schedule/family.rs
+++ b/src/schedule/family.rs
@@ -1,5 +1,6 @@
 use std::ops::{Index, IndexMut};
 use std::slice::{Iter as SliceIter, IterMut as SliceIterMut};
+use std::vec::{IntoIter as VecIntoIter};
 
 use hal::queue::QueueFamilyId;
 
@@ -28,14 +29,19 @@ impl<S> Family<S> {
         self.id
     }
 
-    /// Get iterator over references to queues
+    /// Iterate over immutable references to each queue in this family
     pub fn iter(&self) -> SliceIter<Queue<S>> {
         self.queues.iter()
     }
 
-    /// Get iterator over mutable references to queues
+    /// Iterate over mutable references to each queue in this family
     pub fn iter_mut(&mut self) -> SliceIterMut<Queue<S>> {
         self.queues.iter_mut()
+    }
+
+    /// Iterate over owned queue in this family
+    pub fn into_iter(self) -> VecIntoIter<Queue<S>> {
+        self.queues.into_iter()
     }
 
     /// Get reference to `Queue` instance by the id.
@@ -97,6 +103,33 @@ impl<S> Family<S> {
         assert_eq!(self.id, sid.family());
         self.queue_mut(sid.queue())
             .and_then(|queue| queue.submission_mut(sid))
+    }
+}
+
+impl<S> IntoIterator for Family<S> {
+    type Item = Queue<S>;
+    type IntoIter = VecIntoIter<Queue<S>>;
+
+    fn into_iter(self) -> VecIntoIter<Queue<S>> {
+        self.into_iter()
+    }
+}
+
+impl<'a, S> IntoIterator for &'a Family<S> {
+    type Item = &'a Queue<S>;
+    type IntoIter = SliceIter<'a, Queue<S>>;
+
+    fn into_iter(self) -> SliceIter<'a, Queue<S>> {
+        self.iter()
+    }
+}
+
+impl<'a, S> IntoIterator for &'a mut Family<S> {
+    type Item = &'a mut Queue<S>;
+    type IntoIter = SliceIterMut<'a, Queue<S>>;
+
+    fn into_iter(self) -> SliceIterMut<'a, Queue<S>> {
+        self.iter_mut()
     }
 }
 

--- a/src/schedule/queue.rs
+++ b/src/schedule/queue.rs
@@ -128,7 +128,7 @@ impl<S> DoubleEndedIterator for QueueIntoIter<S> {
 impl<S> ExactSizeIterator for QueueIntoIter<S> {}
 
 /// Instances of this type contains array of `Submission`s.
-/// Those submissions are expected to be submissionted in order.
+/// Those submissions are expected to be submitted in order.
 #[derive(Clone, Debug)]
 pub struct Queue<S> {
     id: QueueId,

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -300,14 +300,14 @@ impl<S, W> SyncData<S, W> {
             acquire: Guard {
                 wait: self.acquire.wait,
                 signal: self.acquire.signal.into_iter().map(|Signal(semaphore)| Signal(f(semaphore))).collect(),
-                buffers: self.acquire.buffers.clone(),
-                images: self.acquire.images.clone(),
+                buffers: self.acquire.buffers,
+                images: self.acquire.images,
             },
             release: Guard {
                 wait: self.release.wait,
                 signal: self.release.signal.into_iter().map(|Signal(semaphore)| Signal(f(semaphore))).collect(),
-                buffers: self.release.buffers.clone(),
-                images: self.release.images.clone(),
+                buffers: self.release.buffers,
+                images: self.release.images,
             },
         }
     }
@@ -320,14 +320,14 @@ impl<S, W> SyncData<S, W> {
             acquire: Guard {
                 wait: self.acquire.wait.into_iter().map(|Wait(semaphore, stage)| Wait(f(semaphore), stage)).collect(),
                 signal: self.acquire.signal,
-                buffers: self.acquire.buffers.clone(),
-                images: self.acquire.images.clone(),
+                buffers: self.acquire.buffers,
+                images: self.acquire.images,
             },
             release: Guard {
                 wait: self.release.wait.into_iter().map(|Wait(semaphore, stage)| Wait(f(semaphore), stage)).collect(),
                 signal: self.release.signal,
-                buffers: self.release.buffers.clone(),
-                images: self.release.images.clone(),
+                buffers: self.release.buffers,
+                images: self.release.images,
             },
         }
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -492,7 +492,8 @@ fn sync_submission_chain<R, S>(
             }
         } else {
             // Same family or content discarding.
-            for tail in prev.tails() {
+            for (queue_id, queue) in prev.queues() {
+                let tail = SubmissionId::new(queue_id, queue.last());
                 if tail.queue() != sid.queue() {
                     // Wait for tails on other queues.
                     sync.acquire.wait.push(Wait::new(
@@ -567,7 +568,9 @@ fn sync_submission_chain<R, S>(
             }
         } else {
             // Same family or content discarding.
-            for head in next.heads() {
+            for (queue_id, queue) in next.queues() {
+                let head = SubmissionId::new(queue_id, queue.first());
+
                 if head.queue() != sid.queue() {
                     // Signal to heads on other queues.
                     sync.release.signal.push(Signal::new(Semaphore::new(

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -360,7 +360,7 @@ pub fn sync<F, S, W>(
                 match signals.get_mut(&semaphore) {
                     None => {
                         let (signal, wait) = new_semaphore();
-                        assert!(waits.insert(semaphore, Some(wait)).is_none());
+                        debug_assert!(waits.insert(semaphore, Some(wait)).is_none());
                         signal
                     }
                     Some(signal) => {
@@ -372,7 +372,7 @@ pub fn sync<F, S, W>(
                 match waits.get_mut(&semaphore) {
                     None => {
                         let (signal, wait) = new_semaphore();
-                        assert!(signals.insert(semaphore, Some(signal)).is_none());
+                        debug_assert!(signals.insert(semaphore, Some(signal)).is_none());
                         wait
                     }
                     Some(wait) => {
@@ -380,12 +380,12 @@ pub fn sync<F, S, W>(
                     }
                 }
             });
-            assert_eq!(sid, new_queue.add_submission(submission.set_sync(sync)));
+            debug_assert_eq!(sid, new_queue.add_submission(submission.set_sync(sync)));
         }
     }
 
-    assert!(signals.values().all(|x| x.is_none()));
-    assert!(waits.values().all(|x| x.is_none()));
+    debug_assert!(signals.values().all(|x| x.is_none()));
+    debug_assert!(waits.values().all(|x| x.is_none()));
 
     result
 }
@@ -432,10 +432,10 @@ fn sync_submission_chain<R, S>(
     Guard<Semaphore, Semaphore>: Pick<R, Target = Barriers<R>>,
 {
     let ref this = chain.links()[link_index];
-    assert_eq!(this.family(), sid.family());
+    debug_assert_eq!(this.family(), sid.family());
     let ref queue = this.queue(sid.queue()).unwrap();
-    assert!(queue.first() <= sid.index());
-    assert!(queue.last() >= sid.index());
+    debug_assert!(queue.first() <= sid.index());
+    debug_assert!(queue.last() >= sid.index());
 
     let this_state = this.queue_state(sid.queue());
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -9,10 +9,10 @@ use std::ops::{Range, RangeFrom, RangeTo};
 use hal::pso::PipelineStage;
 
 use Pick;
-use chain::{BufferChains, Chain, ImageChains, Link};
+use chain::{Chain, Link};
 use collect::{Chains, Unsynchronized};
 use resource::{Access, Buffer, Id, Image, Resource, State};
-use schedule::{QueueId, Schedule, Submission, SubmissionId};
+use schedule::{QueueId, Schedule, SubmissionId};
 
 fn earlier_stage(stages: PipelineStage) -> PipelineStage {
     PipelineStage::from_bits((stages.bits() - 1) ^ (stages.bits())).unwrap()
@@ -88,13 +88,9 @@ struct Semaphore {
 }
 
 impl Semaphore {
-    fn new<R>(id: Id<R>, points: Range<Point>) -> Self
-    where
-        R: Resource,
-        Id<R>: Into<Uid>,
-    {
+    fn new(id: Uid, points: Range<Point>) -> Self {
         Semaphore {
-            id: id.into(),
+            id,
             points,
         }
     }
@@ -328,6 +324,13 @@ impl<S, W> SyncData<S, W> {
     }
 }
 
+struct SyncTemp(HashMap<SubmissionId, SyncData<Semaphore, Semaphore>>);
+impl SyncTemp {
+    fn get_sync(&mut self, sid: SubmissionId) -> &mut SyncData<Semaphore, Semaphore> {
+        self.0.entry(sid).or_insert_with(|| SyncData::new())
+    }
+}
+
 /// Find required synchronization for all submissions in `Chains`.
 pub fn sync<F, S, W>(
     chains: &Chains<Unsynchronized>,
@@ -339,12 +342,13 @@ pub fn sync<F, S, W>(
     let ref buffers = chains.buffers;
     let ref images = chains.images;
 
-    let mut sync = schedule
-        .iter()
-        .flat_map(|family| family.iter())
-        .flat_map(|queue| queue.iter())
-        .map(|(sid, submission)| (sid, sync_submission(sid, submission, buffers, images, schedule)))
-        .collect();
+    let mut sync = SyncTemp(HashMap::new());
+    for (&id, chain) in buffers {
+        sync_chain(id, chain, schedule, &mut sync);
+    }
+    for (&id, chain) in images {
+        sync_chain(id, chain, schedule, &mut sync);
+    }
 
     optimize(schedule, &mut sync);
 
@@ -355,35 +359,40 @@ pub fn sync<F, S, W>(
     for queue in schedule.iter().flat_map(|family| family.iter()) {
         let new_queue = result.ensure_queue(queue.id());
         for (sid, submission) in queue.iter() {
-            let sync = sync.remove(&sid).unwrap();
-            let sync = sync.convert_signal(|semaphore| {
-                match signals.get_mut(&semaphore) {
-                    None => {
-                        let (signal, wait) = new_semaphore();
-                        debug_assert!(waits.insert(semaphore, Some(wait)).is_none());
-                        signal
+            let sync = if let Some(sync) = sync.0.remove(&sid) {
+                let sync = sync.convert_signal(|semaphore| {
+                    match signals.get_mut(&semaphore) {
+                        None => {
+                            let (signal, wait) = new_semaphore();
+                            debug_assert!(waits.insert(semaphore, Some(wait)).is_none());
+                            signal
+                        }
+                        Some(signal) => {
+                            signal.take().unwrap()
+                        }
                     }
-                    Some(signal) => {
-                        signal.take().unwrap()
+                });
+                let sync = sync.convert_wait(|semaphore| {
+                    match waits.get_mut(&semaphore) {
+                        None => {
+                            let (signal, wait) = new_semaphore();
+                            debug_assert!(signals.insert(semaphore, Some(signal)).is_none());
+                            wait
+                        }
+                        Some(wait) => {
+                            wait.take().unwrap()
+                        }
                     }
-                }
-            });
-            let sync = sync.convert_wait(|semaphore| {
-                match waits.get_mut(&semaphore) {
-                    None => {
-                        let (signal, wait) = new_semaphore();
-                        debug_assert!(signals.insert(semaphore, Some(signal)).is_none());
-                        wait
-                    }
-                    Some(wait) => {
-                        wait.take().unwrap()
-                    }
-                }
-            });
+                });
+                sync
+            } else {
+                SyncData::new()
+            };
             debug_assert_eq!(sid, new_queue.add_submission(submission.set_sync(sync)));
         }
     }
 
+    debug_assert!(sync.0.is_empty());
     debug_assert!(signals.values().all(|x| x.is_none()));
     debug_assert!(waits.values().all(|x| x.is_none()));
 
@@ -396,7 +405,7 @@ where
 {
     let (_, sid) = link.queues()
         .map(|(qid, queue)| {
-            let sid = SubmissionId::new(qid, queue.last());
+            let sid = SubmissionId::new(qid, queue.last);
             (schedule[sid].wait_factor(), sid)
         })
         .max_by_key(|&(wait_factor, sid)| (wait_factor, sid.queue().index()))
@@ -410,7 +419,7 @@ where
 {
     let (_, sid) = link.queues()
         .map(|(qid, queue)| {
-            let sid = SubmissionId::new(qid, queue.first());
+            let sid = SubmissionId::new(qid, queue.first);
             (schedule[sid].wait_factor(), sid)
         })
         .min_by_key(|&(wait_factor, sid)| (wait_factor, sid.queue().index()))
@@ -418,201 +427,129 @@ where
     sid
 }
 
-fn sync_submission_chain<R, S>(
-    sid: SubmissionId,
-    _submission: &Submission<S>,
-    link_index: usize,
+fn generate_semaphore_pair<R: Resource>(
+    sync: &mut SyncTemp, id: Uid, link: &Link<R>,
+    range: Range<SubmissionId>, sides: Range<Side>,
+) {
+    let points = Point::new(range.start, sides.start) .. Point::new(range.end, sides.end);
+    if points.start.sid.queue() != points.end.sid.queue() {
+        let semaphore = Semaphore::new(id, points.clone());
+        sync.get_sync(points.start.sid).get_mut(points.start.side).signal
+            .push(Signal::new(semaphore.clone()));
+        sync.get_sync(points.end.sid).get_mut(points.end.side).wait
+            .push(Wait::new(semaphore, link.queue(points.end.sid.queue()).stages));
+    }
+}
+
+fn sync_chain<R, S>(
     id: Id<R>,
     chain: &Chain<R>,
     schedule: &Schedule<S>,
-    sync: &mut SyncData<Semaphore, Semaphore>,
+    sync: &mut SyncTemp,
 ) where
     R: Resource,
     Id<R>: Into<Uid>,
     Guard<Semaphore, Semaphore>: Pick<R, Target = Barriers<R>>,
 {
-    let ref this = chain.links()[link_index];
-    debug_assert_eq!(this.family(), sid.family());
-    let ref queue = this.queue(sid.queue()).unwrap();
-    debug_assert!(queue.first() <= sid.index());
-    debug_assert!(queue.last() >= sid.index());
+    let uid = id.into();
+    for (prev_link, link) in chain.links().into_iter().skip(1).zip(chain.links().into_iter()) {
+        if prev_link.family() == link.family() {
+            // Prefer to generate barriers on the acquire side, if possible.
+            if prev_link.single_queue() && !link.single_queue() {
+                let signal_sid = latest(prev_link, schedule);
 
-    let this_state = this.queue_state(sid.queue());
+                // Generate barrier in prev link's last submission.
+                sync.get_sync(signal_sid).release.pick_mut()
+                    .insert(id, Barrier::new(prev_link.state()..link.state()));
 
-    if queue.first() == sid.index() && link_index > 0 {
-        // First of queue. Sync with prev.
-        let ref prev = chain.links()[link_index - 1];
-        if prev.family() != this.family() && this.state().access.is_read() {
-            // Transfer ownership.
-            // Find earliest submission from this chain.
-            // It will acquire ownership.
-            let this_earliest = earliest(this, schedule);
-            if this_earliest == sid {
-                // Find latest submission from prev chain.
-                // It will release ownership.
-                let prev_latest = latest(prev, schedule);
-
-                // Wait for release.
-                sync.acquire.wait.push(Wait::new(
-                    Semaphore::new(
-                        id,
-                        Point::new(prev_latest, Side::Release)..Point::new(sid, Side::Acquire),
-                    ),
-                    this_state.stages,
-                ));
-
-                // Acquire ownership.
-                sync.acquire.pick_mut().insert(
-                    id,
-                    Barrier::acquire(
-                        prev_latest.queue()..sid.queue(),
-                        prev.state().layout..,
-                        ..this_state,
-                    ),
-                );
-
-                // Signal to other queues in this link.
-                for (qid, queue) in this.queues().filter(|&(qid, _)| qid != sid.queue()) {
-                    sync.acquire.signal.push(Signal::new(Semaphore::new(
-                        id,
-                        Point::new(sid, Side::Acquire)
-                            ..Point::new(SubmissionId::new(qid, queue.first()), Side::Acquire),
-                    )));
+                // Generate semaphores between queues in the previous link and the current one.
+                for (queue_id, queue) in link.queues() {
+                    let head = SubmissionId::new(queue_id, queue.first);
+                    generate_semaphore_pair(
+                        sync, uid, link,
+                        signal_sid .. head, Side::Release .. Side::Acquire,
+                    );
                 }
             } else {
-                // This is not the earliest.
-                // Wait for earliest.
-                sync.acquire.wait.push(Wait::new(
-                    Semaphore::new(
-                        id,
-                        Point::new(this_earliest, Side::Acquire)..Point::new(sid, Side::Acquire),
-                    ),
-                    this_state.stages,
-                ));
+                let wait_sid = earliest(link, schedule);
+
+                // Generate semaphores between queues in the previous link and the current one.
+                for (queue_id, queue) in prev_link.queues() {
+                    let tail = SubmissionId::new(queue_id, queue.last);
+                    generate_semaphore_pair(
+                        sync, uid, link,
+                        tail .. wait_sid, Side::Release .. Side::Acquire,
+                    );
+                }
+
+                // Generate barrier in next link's first submission.
+                sync.get_sync(wait_sid).acquire.pick_mut()
+                    .insert(id, Barrier::new(prev_link.state()..link.state()));
+
+                if !link.single_queue() {
+                    // Delay other queues in the link until the barrier finishes
+                    for (queue_id, queue) in link.queues() {
+                        if queue_id != wait_sid.queue() {
+                            let head = SubmissionId::new(queue_id, queue.first);
+                            generate_semaphore_pair(
+                                sync, uid, link,
+                                wait_sid .. head, Side::Acquire .. Side::Acquire,
+                            );
+                        }
+                    }
+                }
             }
         } else {
-            // Same family or content discarding.
-            for (queue_id, queue) in prev.queues() {
-                let tail = SubmissionId::new(queue_id, queue.last());
-                if tail.queue() != sid.queue() {
-                    // Wait for tails on other queues.
-                    sync.acquire.wait.push(Wait::new(
-                        Semaphore::new(
-                            id,
-                            Point::new(tail, Side::Release)..Point::new(sid, Side::Acquire),
-                        ),
-                        this_state.stages,
-                    ));
-                } else if !prev.single_queue() {
-                    // Insert barrier here.
-                    // Prev won't insert as it isn't exclusive.
-                    assert!(this.single_queue(),
-                            "Barriers cannot currently be inserted between links that both \
-                             involve more than one queue.");
-                    sync.acquire
-                        .pick_mut()
-                        .insert(id, Barrier::new(prev.queue_state(tail.queue())..this_state));
+            let signal_sid = latest(prev_link, schedule);
+            let wait_sid = earliest(link, schedule);
+
+            if !prev_link.single_queue() {
+                // Delay the last submission in the queue until other queues finish
+                for (queue_id, queue) in link.queues() {
+                    if queue_id != signal_sid.queue() {
+                        let tail = SubmissionId::new(queue_id, queue.last);
+                        generate_semaphore_pair(
+                            sync, uid, prev_link,
+                            tail .. signal_sid, Side::Release .. Side::Release,
+                        );
+                    }
+                }
+            }
+
+            // Generate a semaphore between the signal and wait sides of the transfer.
+            generate_semaphore_pair(
+                sync, uid, link,
+                signal_sid .. wait_sid, Side::Release .. Side::Acquire,
+            );
+
+            // Generate barriers to transfer the resource to another queue.
+            sync.get_sync(signal_sid).release.pick_mut()
+                .insert(id, Barrier::release(
+                    signal_sid.queue() .. wait_sid.queue(),
+                    prev_link.queue_state(signal_sid.queue()) ..,
+                    .. link.state().layout,
+                ));
+            sync.get_sync(wait_sid).acquire.pick_mut()
+                .insert(id, Barrier::acquire(
+                    signal_sid.queue() .. wait_sid.queue(),
+                    prev_link.state().layout ..,
+                    .. link.queue_state(wait_sid.queue()),
+                ));
+
+            if !link.single_queue() {
+                // Delay other queues in the link until the barrier finishes
+                for (queue_id, queue) in link.queues() {
+                    if queue_id != wait_sid.queue() {
+                        let head = SubmissionId::new(queue_id, queue.first);
+                        generate_semaphore_pair(
+                            sync, uid, link,
+                            wait_sid .. head, Side::Acquire .. Side::Acquire,
+                        );
+                    }
                 }
             }
         }
     }
-
-    if queue.last() == sid.index() && link_index + 1 < chain.links().len() {
-        // Sync with next.
-        let ref next = chain.links()[link_index + 1];
-        if next.family() != this.family() && next.state().access.is_read() {
-            // Transfer ownership.
-
-            // Find latest submission from this chain.
-            // It will release ownership.
-            let this_latest = latest(this, schedule);
-            if this_latest == sid {
-                // Wait for other queues in this link.
-                for (qid, queue) in this.queues().filter(|&(qid, _)| qid != sid.queue()) {
-                    sync.release.wait.push(Wait::new(
-                        Semaphore::new(
-                            id,
-                            Point::new(SubmissionId::new(qid, queue.last()), Side::Release)
-                                ..Point::new(sid, Side::Release),
-                        ),
-                        PipelineStage::TOP_OF_PIPE,
-                    ));
-                }
-
-                // Find earliest submission from next chain.
-                // It will acquire ownership.
-                let next_earliest = earliest(next, schedule);
-
-                // Release ownership.
-                sync.release.pick_mut().insert(
-                    id,
-                    Barrier::release(
-                        sid.queue()..next_earliest.queue(),
-                        this_state..,
-                        ..next.state().layout,
-                    ),
-                );
-
-                // Signal to acquire.
-                sync.release.signal.push(Signal::new(Semaphore::new(
-                    id,
-                    Point::new(sid, Side::Release)..Point::new(next_earliest, Side::Acquire),
-                )));
-            } else {
-                // This is not the latest.
-                // Signal to latest.
-                sync.release.signal.push(Signal::new(Semaphore::new(
-                    id,
-                    Point::new(sid, Side::Release)..Point::new(this_latest, Side::Release),
-                )));
-            }
-        } else {
-            // Same family or content discarding.
-            for (queue_id, queue) in next.queues() {
-                let head = SubmissionId::new(queue_id, queue.first());
-
-                if head.queue() != sid.queue() {
-                    // Signal to heads on other queues.
-                    sync.release.signal.push(Signal::new(Semaphore::new(
-                        id,
-                        Point::new(sid, Side::Release)..Point::new(head, Side::Acquire),
-                    )));
-                } else if this.single_queue() {
-                    // Insert barrier here.
-                    // Next won't insert as this is exclusive.
-                    sync.release
-                        .pick_mut()
-                        .insert(id, Barrier::new(this_state..next.queue_state(head.queue())));
-                } else {
-                    // Next will insert barrier.
-                    assert!(next.single_queue(),
-                            "Barriers cannot currently be inserted between links that both \
-                             involve more than one queue.");
-                }
-            }
-        }
-    }
-}
-
-fn sync_submission<S>(
-    sid: SubmissionId,
-    submission: &Submission<S>,
-    buffers: &BufferChains,
-    images: &ImageChains,
-    schedule: &Schedule<S>,
-) -> SyncData<Semaphore, Semaphore> {
-    let mut sync = SyncData::new();
-    for (&id, &index) in submission.buffers() {
-        let ref chain = buffers[&id];
-        sync_submission_chain(sid, submission, index, id, chain, schedule, &mut sync);
-    }
-
-    for (&id, &index) in submission.images() {
-        let ref chain = images[&id];
-        sync_submission_chain(sid, submission, index, id, chain, schedule, &mut sync);
-    }
-
-    sync
 }
 
 fn optimize_side(
@@ -644,20 +581,23 @@ fn optimize_side(
 
 fn optimize_submission(
     sid: SubmissionId,
+    to_remove: &mut Vec<Semaphore>,
     found: &mut HashMap<QueueId, (usize, Side)>,
-    sync: &mut HashMap<SubmissionId, SyncData<Semaphore, Semaphore>>,
+    sync: &mut SyncTemp,
 ) {
-    let mut to_remove = Vec::new();
-
     {
-        let sync_data = sync.get_mut(&sid).unwrap();
-        optimize_side(&mut sync_data.acquire, &mut to_remove, found);
-        optimize_side(&mut sync_data.release, &mut to_remove, found);
+        let sync_data = sync.0.get_mut(&sid);
+        if let Some(sync_data) = sync_data {
+            optimize_side(&mut sync_data.acquire, to_remove, found);
+            optimize_side(&mut sync_data.release, to_remove, found);
+        } else {
+            return
+        }
     }
 
-    for semaphore in to_remove {
+    for semaphore in to_remove.drain(..) {
         // Delete signal as well.
-        let ref mut signal = sync.get_mut(&semaphore.points.start.sid)
+        let ref mut signal = sync.0.get_mut(&semaphore.points.start.sid)
             .unwrap()
             .get_mut(semaphore.points.start.side)
             .signal;
@@ -668,12 +608,13 @@ fn optimize_submission(
 
 fn optimize<S>(
     schedule: &Schedule<S>,
-    sync: &mut HashMap<SubmissionId, SyncData<Semaphore, Semaphore>>,
+    sync: &mut SyncTemp,
 ) {
+    let mut to_remove = Vec::new();
     for queue in schedule.iter().flat_map(|family| family.iter()) {
         let mut found = HashMap::new();
         for (sid, _) in queue.iter() {
-            optimize_submission(sid, &mut found, sync);
+            optimize_submission(sid, &mut to_remove, &mut found, sync);
         }
     }
 }


### PR DESCRIPTION
This PR mainly focuses on optimizing `gfx-chain`. Other changes made:
* Rename `sync::Sync` to `sync::SyncData` to avoid overlapping with a core Rust type's name.
* Add `IntoIterator` implementations to all types in `schedule`.
* `gfx-chain` now handles the case where two adjacent links in a chain both contain multiple queues.
* The `wait_factor` mechanism is now fixed, and isn't universally `0` in all submissions.

Benchmarks before optimization
------------------------------
```
tiny   + single-queue:  67899 iters ran in average 0.047 ± 0.010 ms (0.28% ± 0.06% of 16.6 ms)
tiny   + multi-queue :  43391 iters ran in average 0.080 ± 0.018 ms (0.48% ± 0.11% of 16.6 ms)
small  + single-queue:   6456 iters ran in average 0.560 ± 0.091 ms (3.37% ± 0.55% of 16.6 ms)
small  + multi-queue :   3458 iters ran in average 1.094 ± 0.232 ms (6.59% ± 1.40% of 16.6 ms)
medium + single-queue:   1189 iters ran in average 3.181 ± 0.453 ms (19.16% ± 2.73% of 16.6 ms)
medium + multi-queue :    615 iters ran in average 6.313 ± 0.877 ms (38.03% ± 5.28% of 16.6 ms)
large  + single-queue:     28 iters ran in average 142.581 ± 7.033 ms (858.92% ± 42.37% of 16.6 ms)
large  + multi-queue :     18 iters ran in average 221.229 ± 17.011 ms (1332.71% ± 102.48% of 16.6 ms)
huge   + single-queue:     12 iters ran in average 356.965 ± 11.768 ms (2150.39% ± 70.89% of 16.6 ms)
huge   + multi-queue :      8 iters ran in average 527.094 ± 28.118 ms (3175.27% ± 169.38% of 16.6 ms)
```

Benchmarks after optimization
-----------------------------
```
tiny   + single-queue: 124284 iters ran in average 0.021 ± 0.003 ms (0.12% ± 0.02% of 16.6 ms)
tiny   + multi-queue :  83506 iters ran in average 0.036 ± 0.005 ms (0.22% ± 0.03% of 16.6 ms)
small  + single-queue:  17860 iters ran in average 0.166 ± 0.016 ms (1.00% ± 0.10% of 16.6 ms)
small  + multi-queue :  11654 iters ran in average 0.285 ± 0.031 ms (1.71% ± 0.18% of 16.6 ms)
medium + single-queue:   5242 iters ran in average 0.594 ± 0.054 ms (3.58% ± 0.32% of 16.6 ms)
medium + multi-queue :   3489 iters ran in average 0.976 ± 0.080 ms (5.88% ± 0.48% of 16.6 ms)
large  + single-queue:    346 iters ran in average 10.206 ± 0.559 ms (61.48% ± 3.37% of 16.6 ms)
large  + multi-queue :    213 iters ran in average 17.310 ± 0.632 ms (104.27% ± 3.81% of 16.6 ms)
huge   + single-queue:    188 iters ran in average 19.098 ± 0.699 ms (115.05% ± 4.21% of 16.6 ms)
huge   + multi-queue :    122 iters ran in average 30.534 ± 1.285 ms (183.94% ± 7.74% of 16.6 ms)
```