### PR TITLE
Implement schedule simulator in the fuzzer, further performance improvements and bug fixes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,8 @@ license = "MIT/Apache-2.0"
 debug = 2
 
 [dependencies]
-derivative = "1.0"
+fnv = "1.0"
 gfx-hal = { version = "0.1.0", git = "https://github.com/gfx-rs/gfx", rev = "1e959ace6" }
-log = "0.4"
 
 [dev-dependencies]
 clap = "2.31"

--- a/examples/random_chains.rs
+++ b/examples/random_chains.rs
@@ -1,9 +1,11 @@
 extern crate clap;
+extern crate fnv;
 extern crate gfx_hal as hal;
 extern crate gfx_chain;
 extern crate rand;
 
 use clap::{Arg, App, SubCommand};
+use fnv::FnvHashMap;
 use gfx_chain::chain::Chain;
 use gfx_chain::collect::{Chains, collect};
 use gfx_chain::pass::{Pass, PassId, StateUsage};
@@ -350,7 +352,7 @@ impl <'a, 'b> ExecuteStatus<'a, 'b> {
     }
 
     fn check_pass_state<R: Resource>(
-        map: &HashMap<Id<R>, ResourceState<R>>, chains: &HashMap<Id<R>, Chain<R>>,
+        map: &HashMap<Id<R>, ResourceState<R>>, chains: &FnvHashMap<Id<R>, Chain<R>>,
         current_family: QueueFamilyId, id: Id<R>, expected_state: StateUsage<R>, link_id: usize,
     ) {
         let state = *map.get(&id).expect("Resource not in chain!");

--- a/src/chain/link.rs
+++ b/src/chain/link.rs
@@ -158,7 +158,7 @@ where
     pub(crate) fn queue_state(&self, qid: QueueId) -> State<R> {
         let queue = self.queue(qid);
         State {
-            access: self.state.access,
+            access: queue.access,
             stages: queue.stages,
             .. self.state
         }

--- a/src/chain/link.rs
+++ b/src/chain/link.rs
@@ -158,7 +158,7 @@ where
     pub(crate) fn queue_state(&self, qid: QueueId) -> State<R> {
         let queue = self.queue(qid);
         State {
-            access: queue.access,
+            access: self.state.access,
             stages: queue.stages,
             .. self.state
         }

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -7,7 +7,7 @@
 
 mod link;
 
-use std::collections::HashMap;
+use fnv::FnvHashMap;
 use std::ops::BitOr;
 use resource::{Buffer, Id, Image, Resource, Usage};
 
@@ -88,7 +88,7 @@ where
 }
 
 /// Type alias for map of chains by id for buffers.
-pub type BufferChains = HashMap<Id<Buffer>, Chain<Buffer>>;
+pub type BufferChains = FnvHashMap<Id<Buffer>, Chain<Buffer>>;
 
 /// Type alias for map of chains by id for images.
-pub type ImageChains = HashMap<Id<Image>, Chain<Image>>;
+pub type ImageChains = FnvHashMap<Id<Image>, Chain<Image>>;

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -133,6 +133,7 @@ where
                 pass,
                 0,
                 scheduled,
+                scheduled,
                 &mut schedule,
                 &mut images,
                 &mut buffers,
@@ -165,6 +166,7 @@ where
                 pass,
                 qid,
                 fitness.wait_factor,
+                scheduled,
                 &mut schedule,
                 &mut images,
                 &mut buffers,
@@ -337,6 +339,7 @@ fn schedule_pass<'a>(
     pass: &ResolvedPass,
     queue: usize,
     wait_factor: usize,
+    submitted: usize,
     schedule: &mut Vec<QueueData>,
     images: &mut Vec<ChainData<Image>>,
     buffers: &mut Vec<ChainData<Buffer>>,
@@ -344,7 +347,8 @@ fn schedule_pass<'a>(
     let pid = passes.pass_ids[pass.id];
     let ref mut queue_data = schedule[queue];
     queue_data.wait_factor = max(queue_data.wait_factor, wait_factor + 1);
-    let sid = queue_data.queue.add_submission(Submission::new(wait_factor, pid, Unsynchronized));
+    let submission = Submission::new(wait_factor, submitted, pid, Unsynchronized);
+    let sid = queue_data.queue.add_submission(submission);
     let ref mut submission = queue_data.queue[sid];
 
     for &(id, StateUsage { state, usage }) in &pass.buffers {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #![deny(unused_must_use)]
 #![deny(dead_code)]
 
+extern crate fnv;
 extern crate gfx_hal as hal;
 
 use hal::queue::QueueFamilyId;

--- a/src/resource/access.rs
+++ b/src/resource/access.rs
@@ -1,9 +1,11 @@
 use std::fmt::Debug;
-use std::ops::{BitOr, BitOrAssign};
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign};
 use hal::pso::PipelineStage;
 
 /// Access type combination
-pub trait Access: Debug + Copy + BitOr<Output = Self> + BitOrAssign + Eq {
+pub trait Access: Debug + Copy + Eq +
+                  BitAnd<Output = Self> + BitAndAssign +
+                  BitOr<Output = Self> + BitOrAssign {
     /// Create empty combinations of access types.
     fn none() -> Self;
 

--- a/src/schedule/family.rs
+++ b/src/schedule/family.rs
@@ -24,6 +24,11 @@ impl<S> Family<S> {
         }
     }
 
+    /// The number of queues in this family.
+    pub fn queue_count(&self) -> usize {
+        self.queues.len()
+    }
+
     /// Get id of the family.
     pub fn id(&self) -> QueueFamilyId {
         self.id

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -12,7 +12,8 @@ mod family;
 mod submission;
 mod queue;
 
-use std::collections::hash_map::{HashMap, Values as HashMapValues, ValuesMut as HashMapValuesMut,
+use fnv::FnvHashMap;
+use std::collections::hash_map::{Values as HashMapValues, ValuesMut as HashMapValuesMut,
                                  IntoIter as HashMapIntoIter};
 use std::ops::{Index, IndexMut};
 
@@ -25,14 +26,14 @@ pub use self::queue::{Queue, QueueId, QueueIter, QueueIterMut};
 /// All schedule on which passes were scheduled.
 #[derive(Debug)]
 pub struct Schedule<S> {
-    map: HashMap<QueueFamilyId, Family<S>>,
+    map: FnvHashMap<QueueFamilyId, Family<S>>,
 }
 
 impl<S> Schedule<S> {
     /// Create new empty `Schedule`
     pub fn new() -> Self {
         Schedule {
-            map: HashMap::new()
+            map: FnvHashMap::default(),
         }
     }
 

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -36,6 +36,16 @@ impl<S> Schedule<S> {
         }
     }
 
+    /// The number of families in this schedule.
+    pub fn family_count(&self) -> usize {
+        self.map.len()
+    }
+
+    /// The number of queues in this schedule.
+    pub fn queue_count(&self) -> usize {
+        self.map.iter().map(|x| x.1.queue_count()).sum()
+    }
+
     /// Iterate over immutable references to families in this schedule.
     pub fn iter(&self) -> HashMapValues<QueueFamilyId, Family<S>> {
         self.map.values()

--- a/src/schedule/submission.rs
+++ b/src/schedule/submission.rs
@@ -1,4 +1,5 @@
-use std::collections::hash_map::{HashMap, Iter as HashMapIter};
+use fnv::FnvHashMap;
+use std::collections::hash_map::{Iter as HashMapIter};
 
 use hal::queue::QueueFamilyId;
 
@@ -40,8 +41,8 @@ impl SubmissionId {
 /// This type corresponds to commands that should be recorded into single primary command buffer.
 #[derive(Clone, Debug)]
 pub struct Submission<S> {
-    buffers: HashMap<Id<Buffer>, usize>,
-    images: HashMap<Id<Image>, usize>,
+    buffers: FnvHashMap<Id<Buffer>, usize>,
+    images: FnvHashMap<Id<Image>, usize>,
     pass: PassId,
     wait_factor: usize,
     sync: S,
@@ -86,8 +87,8 @@ impl<S> Submission<S> {
     /// Create new submission with specified pass.
     pub(crate) fn new(wait_factor: usize, pass: PassId, sync: S) -> Self {
         Submission {
-            buffers: HashMap::new(),
-            images: HashMap::new(),
+            buffers: FnvHashMap::default(),
+            images: FnvHashMap::default(),
             pass,
             wait_factor,
             sync,
@@ -107,23 +108,23 @@ impl<S> Submission<S> {
 }
 
 impl<S> Pick<Buffer> for Submission<S> {
-    type Target = HashMap<Id<Buffer>, usize>;
+    type Target = FnvHashMap<Id<Buffer>, usize>;
 
-    fn pick(&self) -> &HashMap<Id<Buffer>, usize> {
+    fn pick(&self) -> &FnvHashMap<Id<Buffer>, usize> {
         &self.buffers
     }
-    fn pick_mut(&mut self) -> &mut HashMap<Id<Buffer>, usize> {
+    fn pick_mut(&mut self) -> &mut FnvHashMap<Id<Buffer>, usize> {
         &mut self.buffers
     }
 }
 
 impl<S> Pick<Image> for Submission<S> {
-    type Target = HashMap<Id<Image>, usize>;
+    type Target = FnvHashMap<Id<Image>, usize>;
 
-    fn pick(&self) -> &HashMap<Id<Image>, usize> {
+    fn pick(&self) -> &FnvHashMap<Id<Image>, usize> {
         &self.images
     }
-    fn pick_mut(&mut self) -> &mut HashMap<Id<Image>, usize> {
+    fn pick_mut(&mut self) -> &mut FnvHashMap<Id<Image>, usize> {
         &mut self.images
     }
 }

--- a/src/schedule/submission.rs
+++ b/src/schedule/submission.rs
@@ -45,6 +45,7 @@ pub struct Submission<S> {
     images: FnvHashMap<Id<Image>, usize>,
     pass: PassId,
     wait_factor: usize,
+    submit_order: usize,
     sync: S,
 }
 
@@ -62,6 +63,11 @@ impl<S> Submission<S> {
     /// Get wait factor for `Submission`
     pub fn wait_factor(&self) -> usize {
         self.wait_factor
+    }
+
+    /// Get submit order for `Submission`
+    pub fn submit_order(&self) -> usize {
+        self.submit_order
     }
 
     /// Iterator over buffers
@@ -85,12 +91,13 @@ impl<S> Submission<S> {
     }
 
     /// Create new submission with specified pass.
-    pub(crate) fn new(wait_factor: usize, pass: PassId, sync: S) -> Self {
+    pub(crate) fn new(wait_factor: usize, submit_order: usize, pass: PassId, sync: S) -> Self {
         Submission {
             buffers: FnvHashMap::default(),
             images: FnvHashMap::default(),
             pass,
             wait_factor,
+            submit_order,
             sync,
         }
     }
@@ -102,6 +109,7 @@ impl<S> Submission<S> {
             images: self.images.clone(),
             pass: self.pass,
             wait_factor: self.wait_factor,
+            submit_order: self.submit_order,
             sync,
         }
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -531,14 +531,16 @@ fn sync_chain<R, S>(
             sync.get_sync(signal_sid).release.pick_mut()
                 .insert(id, Barrier::release(
                     signal_sid.queue() .. wait_sid.queue(),
-                    prev_link.queue_state(signal_sid.queue()) ..,
+                    State { access: prev_link.state().access,
+                            ..prev_link.queue_state(signal_sid.queue()) } ..,
                     .. link.state().layout,
                 ));
             sync.get_sync(wait_sid).acquire.pick_mut()
                 .insert(id, Barrier::acquire(
                     signal_sid.queue() .. wait_sid.queue(),
                     prev_link.state().layout ..,
-                    .. link.queue_state(wait_sid.queue()),
+                    .. State { access: link.state().access,
+                               ..link.queue_state(wait_sid.queue()) },
                 ));
 
             if !link.single_queue() {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -349,7 +349,9 @@ pub fn sync<F, S, W>(
         sync_chain(id, chain, schedule, &mut sync);
     }
 
-    optimize(schedule, &mut sync);
+    if schedule.queue_count() > 1 {
+        optimize(schedule, &mut sync);
+    }
 
     let mut result = Schedule::default();
     let mut signals: HashMap<Semaphore, Option<S>> = HashMap::new();

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -509,7 +509,7 @@ fn sync_chain<R, S>(
 
             if !prev_link.single_queue() {
                 // Delay the last submission in the queue until other queues finish
-                for (queue_id, queue) in link.queues() {
+                for (queue_id, queue) in prev_link.queues() {
                     if queue_id != signal_sid.queue() {
                         let tail = SubmissionId::new(queue_id, queue.last);
                         generate_semaphore_pair(


### PR DESCRIPTION
This implements a schedule simulator that simulates random execution orders on a schedule in an attempt to find issues, and fixes several bugs caught by it. 

In addition, it make changes taking advantage of a few additional optimization opportunities, especially when only a single queue is in use.

Before:
```
tiny   + single-queue: 101483 iters ran in average 0.027 ± 0.008 ms (0.16% ± 0.05% of 16.6 ms)
tiny   + multi-queue :  63530 iters ran in average 0.050 ± 0.007 ms (0.30% ± 0.04% of 16.6 ms)
small  + single-queue:  15568 iters ran in average 0.195 ± 0.019 ms (1.17% ± 0.11% of 16.6 ms)
small  + multi-queue :   8918 iters ran in average 0.384 ± 0.050 ms (2.32% ± 0.30% of 16.6 ms)
medium + single-queue:   4605 iters ran in average 0.684 ± 0.080 ms (4.12% ± 0.48% of 16.6 ms)
medium + multi-queue :   2795 iters ran in average 1.248 ± 0.073 ms (7.52% ± 0.44% of 16.6 ms)
large  + single-queue:    293 iters ran in average 12.218 ± 0.440 ms (73.60% ± 2.65% of 16.6 ms)
large  + multi-queue :    182 iters ran in average 20.427 ± 0.705 ms (123.05% ± 4.25% of 16.6 ms)
huge   + single-queue:    162 iters ran in average 22.301 ± 0.904 ms (134.34% ± 5.44% of 16.6 ms)
huge   + multi-queue :    105 iters ran in average 35.773 ± 0.985 ms (215.50% ± 5.93% of 16.6 ms)
```

After:
```
tiny   + single-queue: 124558 iters ran in average 0.019 ± 0.003 ms (0.12% ± 0.02% of 16.6 ms)
tiny   + multi-queue :  70690 iters ran in average 0.043 ± 0.006 ms (0.26% ± 0.04% of 16.6 ms)
small  + single-queue:  19696 iters ran in average 0.138 ± 0.013 ms (0.83% ± 0.08% of 16.6 ms)
small  + multi-queue :   9779 iters ran in average 0.343 ± 0.032 ms (2.06% ± 0.19% of 16.6 ms)
medium + single-queue:   6166 iters ran in average 0.456 ± 0.047 ms (2.75% ± 0.28% of 16.6 ms)
medium + multi-queue :   3148 iters ran in average 1.078 ± 0.066 ms (6.49% ± 0.40% of 16.6 ms)
large  + single-queue:    461 iters ran in average 6.989 ± 0.592 ms (42.10% ± 3.57% of 16.6 ms)
large  + multi-queue :    226 iters ran in average 15.993 ± 0.660 ms (96.34% ± 3.98% of 16.6 ms)
huge   + single-queue:    293 iters ran in average 11.099 ± 0.541 ms (66.86% ± 3.26% of 16.6 ms)
huge   + multi-queue :    135 iters ran in average 26.934 ± 0.881 ms (162.25% ± 5.31% of 16.6 ms)
```
